### PR TITLE
Updated make rule to capture false positive errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,14 @@ list:
 mkdocs:
 	mkdocs serve 
 
+# To supress the error after make command is run
+# such as make: *** No rule to make target 'single-new-eks-awsnative-observability'.  Stop.
 pattern:
 	@echo $(pattern_name) performing $(pattern_command)
 	$(CDK) --app "npx ts-node bin/$(pattern_name).ts" $(if $(pattern_command),$(pattern_command), list)
+	@:
+%:
+	@:
 
 test-all:
 	@for pattern in $(formatted_pattern_names) ; do \


### PR DESCRIPTION
*Issue #, if available:*
Closes: #54 

*Description of changes:*
Added a new rule,` %:`, which is a catch-all rule that does nothing. This rule will match any target that isn't matched by another rule, so make will no longer complain about a missing rule for any pattern deployment as seen in the issue #54.

Please review the proposed change and let me know if this work around is not suitable..

Deployment Test O/p:
```
make pattern single-new-eks-cluster deploy
single-new-eks-cluster performing deploy
node node_modules/.bin/cdk --app "npx ts-node bin/single-new-eks-cluster.ts"    deploy

...
....
.....
......

 ✅  single-new-eks-observability-accelerator

✨  Deployment time: 1147.62s

Outputs:
single-new-eks-observability-accelerator.singleneweksobservabilityacceleratorClusterName69B4FE14 = single-new-eks-observability-accelerator
single-new-eks-observability-accelerator.singleneweksobservabilityacceleratorConfigCommandA6F14F58 = aws eks update-kubeconfig --name single-new-eks-observability-accelerator --region us-west-2 --role-arn arn:aws:iam::******************:role/single-new-eks-observabil-singleneweksobservabilit-N8BI213AK8WT
single-new-eks-observability-accelerator.singleneweksobservabilityacceleratorGetTokenCommand5D9199D7 = aws eks get-token --cluster-name single-new-eks-observability-accelerator --region us-west-2 --role-arn arn:aws:iam::::******************::role/single-new-eks-observabil-singleneweksobservabilit-N8BI213AK8WT
Stack ARN:
arn:aws:cloudformation:us-west-2:::******************::stack/single-new-eks-observability-accelerator/a1d10f60-217f-11ee-ad44-0aa3c362f749

✨  Total time: 1156.49s


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
