### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ We provide curated metrics, logs, traces collection, cloudwatch dashboard, alert
 
 The individual patterns can be found in the `lib` directory.  Most of the patterns are self-explanatory, for some more complex examples please use this guide and docs/patterns directory for more information.
 
-## Documentation
-
-Please refer to the AWS CDK Observability Accelerator [documentation site](https://aws-observability.github.io/cdk-aws-observability-accelerator/) for complete project documentation.
-
 ## Usage
 Before proceeding, make sure [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) is installed on your machine.
 


### PR DESCRIPTION
Removed the documentation section. As the doc is generated from this git repo, this section is redundant. Also when you click on the "documentation site" link in this line "Please refer to the AWS CDK Observability Accelerator documentation site for complete project documentation.", it looks back to the same page.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
