### PR TITLE
Emergency Fix for API Server Dashboard Changes

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -23,7 +23,10 @@
     "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
     "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
     "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
+    "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
+    "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
+    "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
     "existing.cluster.name": "single-new-eks-observability-accelerator",
-    "existing.kubectl.rolename": "YOUR_KUBECTL_ROLE"
+    "existing.kubectl.rolename": "single-new-eks-observabil-singleneweksobservabilit-E4ENDLYB26BZ"
   }
 }

--- a/cdk.json
+++ b/cdk.json
@@ -27,6 +27,6 @@
     "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
     "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
     "existing.cluster.name": "single-new-eks-observability-accelerator",
-    "existing.kubectl.rolename": "single-new-eks-observabil-singleneweksobservabilit-E4ENDLYB26BZ"
+    "existing.kubectl.rolename": "YOUR_KUBECTL_ROLE"
   }
 }

--- a/docs/patterns/existing-eks-observability-accelerators/existing-eks-opensource-observability.md
+++ b/docs/patterns/existing-eks-observability-accelerators/existing-eks-opensource-observability.md
@@ -104,7 +104,10 @@ Example settings: Update the context in `cdk.json` file located in `cdk-eks-blue
         "namespaceworkloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/namespace-workloads.json",
         "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
         "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
-        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json"
+        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
+        "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
+        "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
+        "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
       }
 ```
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-graviton-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-graviton-opensource-observability.md
@@ -103,7 +103,10 @@ Example settings: Update the context in `cdk.json` file located in `cdk-eks-blue
         "namespaceworkloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/namespace-workloads.json",
         "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
         "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
-        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json"
+        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
+        "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
+        "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
+        "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
       }
 ```
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-opensource-observability.md
@@ -94,7 +94,10 @@ Example settings: Update the context in `cdk.json` file located in `cdk-eks-blue
         "namespaceworkloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/namespace-workloads.json",
         "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
         "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
-        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json"
+        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
+        "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
+        "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
+        "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
       }
 ```
 

--- a/lib/existing-eks-opensource-observability-construct/index.ts
+++ b/lib/existing-eks-opensource-observability-construct/index.ts
@@ -45,6 +45,9 @@ export default class ExistingEksOpenSourceobservabilityConstruct {
         const nodeExporterDashUrl: string = utils.valueFromContext(scope, "nodeexporter.dashboard.url", undefined);
         const nodesDashUrl: string = utils.valueFromContext(scope, "nodes.dashboard.url", undefined);
         const workloadsDashUrl: string = utils.valueFromContext(scope, "workloads.dashboard.url", undefined);
+        const apiServerBasicDashUrl: string = utils.valueFromContext(scope, "apiserver.basic.dashboard.url", undefined);
+        const apiServerAdvancedDashUrl: string = utils.valueFromContext(scope, "apiserver.advanced.dashboard.url", undefined);
+        const apiServerTroubleshootingDashUrl: string = utils.valueFromContext(scope, "apiserver.troubleshooting.dashboard.url", undefined);
 
         Reflect.defineMetadata("ordered", true, blueprints.addons.GrafanaOperatorAddon);
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -78,7 +81,10 @@ export default class ExistingEksOpenSourceobservabilityConstruct {
                     "GRAFANA_NSWRKLDS_DASH_URL" : namespaceWorkloadsDashUrl,
                     "GRAFANA_NODEEXP_DASH_URL" : nodeExporterDashUrl,
                     "GRAFANA_NODES_DASH_URL" : nodesDashUrl,
-                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl
+                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl,
+                    "GRAFANA_APISERVER_BASIC_DASH_URL": apiServerBasicDashUrl,
+                    "GRAFANA_APISERVER_ADVANCED_DASH_URL": apiServerAdvancedDashUrl,
+                    "GRAFANA_APISERVER_TROUBLESHOOTING_DASH_URL": apiServerTroubleshootingDashUrl
                 },
             }),
             new GrafanaOperatorSecretAddon(),

--- a/lib/single-new-eks-opensource-observability-construct/graviton-index.ts
+++ b/lib/single-new-eks-opensource-observability-construct/graviton-index.ts
@@ -26,6 +26,9 @@ export default class SingleNewEksGravitonOpenSourceObservabilityConstruct {
         const nodeExporterDashUrl: string = utils.valueFromContext(scope, "nodeexporter.dashboard.url", undefined);
         const nodesDashUrl: string = utils.valueFromContext(scope, "nodes.dashboard.url", undefined);
         const workloadsDashUrl: string = utils.valueFromContext(scope, "workloads.dashboard.url", undefined);
+        const apiServerBasicDashUrl: string = utils.valueFromContext(scope, "apiserver.basic.dashboard.url", undefined);
+        const apiServerAdvancedDashUrl: string = utils.valueFromContext(scope, "apiserver.advanced.dashboard.url", undefined);
+        const apiServerTroubleshootingDashUrl: string = utils.valueFromContext(scope, "apiserver.troubleshooting.dashboard.url", undefined);
 
         Reflect.defineMetadata("ordered", true, blueprints.addons.GrafanaOperatorAddon);
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -62,7 +65,10 @@ export default class SingleNewEksGravitonOpenSourceObservabilityConstruct {
                     "GRAFANA_NSWRKLDS_DASH_URL" : namespaceWorkloadsDashUrl,
                     "GRAFANA_NODEEXP_DASH_URL" : nodeExporterDashUrl,
                     "GRAFANA_NODES_DASH_URL" : nodesDashUrl,
-                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl
+                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl,
+                    "GRAFANA_APISERVER_BASIC_DASH_URL": apiServerBasicDashUrl,
+                    "GRAFANA_APISERVER_ADVANCED_DASH_URL": apiServerAdvancedDashUrl,
+                    "GRAFANA_APISERVER_TROUBLESHOOTING_DASH_URL": apiServerTroubleshootingDashUrl
                 },
             }),
             new GrafanaOperatorSecretAddon(),

--- a/lib/single-new-eks-opensource-observability-construct/index.ts
+++ b/lib/single-new-eks-opensource-observability-construct/index.ts
@@ -27,7 +27,9 @@ export default class SingleNewEksOpenSourceobservabilityConstruct {
         const nodeExporterDashUrl: string = utils.valueFromContext(scope, "nodeexporter.dashboard.url", undefined);
         const nodesDashUrl: string = utils.valueFromContext(scope, "nodes.dashboard.url", undefined);
         const workloadsDashUrl: string = utils.valueFromContext(scope, "workloads.dashboard.url", undefined);
-
+        const apiServerBasicDashUrl: string = utils.valueFromContext(scope, "apiserver.basic.dashboard.url", undefined);
+        const apiServerAdvancedDashUrl: string = utils.valueFromContext(scope, "apiserver.advanced.dashboard.url", undefined);
+        const apiServerTroubleshootingDashUrl: string = utils.valueFromContext(scope, "apiserver.troubleshooting.dashboard.url", undefined);
 
         Reflect.defineMetadata("ordered", true, blueprints.addons.GrafanaOperatorAddon);
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -64,7 +66,10 @@ export default class SingleNewEksOpenSourceobservabilityConstruct {
                     "GRAFANA_NSWRKLDS_DASH_URL" : namespaceWorkloadsDashUrl,
                     "GRAFANA_NODEEXP_DASH_URL" : nodeExporterDashUrl,
                     "GRAFANA_NODES_DASH_URL" : nodesDashUrl,
-                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl
+                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl,
+                    "GRAFANA_APISERVER_BASIC_DASH_URL": apiServerBasicDashUrl,
+                    "GRAFANA_APISERVER_ADVANCED_DASH_URL": apiServerAdvancedDashUrl,
+                    "GRAFANA_APISERVER_TROUBLESHOOTING_DASH_URL": apiServerTroubleshootingDashUrl
                 },
             }),
             new GrafanaOperatorSecretAddon(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fix is an emergency one to avoid breaking changes with CDK observability Accelerator open source patterns for API Server dashboards.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
