### PR TITLE
Revert "Emergency Fix for API Server Dashboard Changes"

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -23,9 +23,6 @@
     "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
     "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
     "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
-    "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
-    "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
-    "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
     "existing.cluster.name": "single-new-eks-observability-accelerator",
     "existing.kubectl.rolename": "YOUR_KUBECTL_ROLE"
   }

--- a/docs/patterns/existing-eks-observability-accelerators/existing-eks-opensource-observability.md
+++ b/docs/patterns/existing-eks-observability-accelerators/existing-eks-opensource-observability.md
@@ -104,10 +104,7 @@ Example settings: Update the context in `cdk.json` file located in `cdk-eks-blue
         "namespaceworkloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/namespace-workloads.json",
         "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
         "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
-        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
-        "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
-        "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
-        "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
+        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json"
       }
 ```
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-graviton-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-graviton-opensource-observability.md
@@ -103,10 +103,7 @@ Example settings: Update the context in `cdk.json` file located in `cdk-eks-blue
         "namespaceworkloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/namespace-workloads.json",
         "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
         "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
-        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
-        "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
-        "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
-        "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
+        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json"
       }
 ```
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-opensource-observability.md
@@ -94,10 +94,7 @@ Example settings: Update the context in `cdk.json` file located in `cdk-eks-blue
         "namespaceworkloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/namespace-workloads.json",
         "nodeexporter.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodeexporter-nodes.json",
         "nodes.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/nodes.json",
-        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json",
-        "apiserver.basic.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-basic.json",
-        "apiserver.advanced.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-advanced.json",
-        "apiserver.troubleshooting.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/apiserver-troubleshooting.json",
+        "workloads.dashboard.url": "https://raw.githubusercontent.com/aws-observability/aws-observability-accelerator/main/artifacts/grafana-dashboards/eks/infrastructure/workloads.json"
       }
 ```
 

--- a/lib/existing-eks-opensource-observability-construct/index.ts
+++ b/lib/existing-eks-opensource-observability-construct/index.ts
@@ -45,9 +45,6 @@ export default class ExistingEksOpenSourceobservabilityConstruct {
         const nodeExporterDashUrl: string = utils.valueFromContext(scope, "nodeexporter.dashboard.url", undefined);
         const nodesDashUrl: string = utils.valueFromContext(scope, "nodes.dashboard.url", undefined);
         const workloadsDashUrl: string = utils.valueFromContext(scope, "workloads.dashboard.url", undefined);
-        const apiServerBasicDashUrl: string = utils.valueFromContext(scope, "apiserver.basic.dashboard.url", undefined);
-        const apiServerAdvancedDashUrl: string = utils.valueFromContext(scope, "apiserver.advanced.dashboard.url", undefined);
-        const apiServerTroubleshootingDashUrl: string = utils.valueFromContext(scope, "apiserver.troubleshooting.dashboard.url", undefined);
 
         Reflect.defineMetadata("ordered", true, blueprints.addons.GrafanaOperatorAddon);
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -81,10 +78,7 @@ export default class ExistingEksOpenSourceobservabilityConstruct {
                     "GRAFANA_NSWRKLDS_DASH_URL" : namespaceWorkloadsDashUrl,
                     "GRAFANA_NODEEXP_DASH_URL" : nodeExporterDashUrl,
                     "GRAFANA_NODES_DASH_URL" : nodesDashUrl,
-                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl,
-                    "GRAFANA_APISERVER_BASIC_DASH_URL": apiServerBasicDashUrl,
-                    "GRAFANA_APISERVER_ADVANCED_DASH_URL": apiServerAdvancedDashUrl,
-                    "GRAFANA_APISERVER_TROUBLESHOOTING_DASH_URL": apiServerTroubleshootingDashUrl
+                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl
                 },
             }),
             new GrafanaOperatorSecretAddon(),

--- a/lib/single-new-eks-opensource-observability-construct/graviton-index.ts
+++ b/lib/single-new-eks-opensource-observability-construct/graviton-index.ts
@@ -26,9 +26,6 @@ export default class SingleNewEksGravitonOpenSourceObservabilityConstruct {
         const nodeExporterDashUrl: string = utils.valueFromContext(scope, "nodeexporter.dashboard.url", undefined);
         const nodesDashUrl: string = utils.valueFromContext(scope, "nodes.dashboard.url", undefined);
         const workloadsDashUrl: string = utils.valueFromContext(scope, "workloads.dashboard.url", undefined);
-        const apiServerBasicDashUrl: string = utils.valueFromContext(scope, "apiserver.basic.dashboard.url", undefined);
-        const apiServerAdvancedDashUrl: string = utils.valueFromContext(scope, "apiserver.advanced.dashboard.url", undefined);
-        const apiServerTroubleshootingDashUrl: string = utils.valueFromContext(scope, "apiserver.troubleshooting.dashboard.url", undefined);
 
         Reflect.defineMetadata("ordered", true, blueprints.addons.GrafanaOperatorAddon);
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -65,10 +62,7 @@ export default class SingleNewEksGravitonOpenSourceObservabilityConstruct {
                     "GRAFANA_NSWRKLDS_DASH_URL" : namespaceWorkloadsDashUrl,
                     "GRAFANA_NODEEXP_DASH_URL" : nodeExporterDashUrl,
                     "GRAFANA_NODES_DASH_URL" : nodesDashUrl,
-                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl,
-                    "GRAFANA_APISERVER_BASIC_DASH_URL": apiServerBasicDashUrl,
-                    "GRAFANA_APISERVER_ADVANCED_DASH_URL": apiServerAdvancedDashUrl,
-                    "GRAFANA_APISERVER_TROUBLESHOOTING_DASH_URL": apiServerTroubleshootingDashUrl
+                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl
                 },
             }),
             new GrafanaOperatorSecretAddon(),

--- a/lib/single-new-eks-opensource-observability-construct/index.ts
+++ b/lib/single-new-eks-opensource-observability-construct/index.ts
@@ -27,9 +27,7 @@ export default class SingleNewEksOpenSourceobservabilityConstruct {
         const nodeExporterDashUrl: string = utils.valueFromContext(scope, "nodeexporter.dashboard.url", undefined);
         const nodesDashUrl: string = utils.valueFromContext(scope, "nodes.dashboard.url", undefined);
         const workloadsDashUrl: string = utils.valueFromContext(scope, "workloads.dashboard.url", undefined);
-        const apiServerBasicDashUrl: string = utils.valueFromContext(scope, "apiserver.basic.dashboard.url", undefined);
-        const apiServerAdvancedDashUrl: string = utils.valueFromContext(scope, "apiserver.advanced.dashboard.url", undefined);
-        const apiServerTroubleshootingDashUrl: string = utils.valueFromContext(scope, "apiserver.troubleshooting.dashboard.url", undefined);
+
 
         Reflect.defineMetadata("ordered", true, blueprints.addons.GrafanaOperatorAddon);
         const addOns: Array<blueprints.ClusterAddOn> = [
@@ -66,10 +64,7 @@ export default class SingleNewEksOpenSourceobservabilityConstruct {
                     "GRAFANA_NSWRKLDS_DASH_URL" : namespaceWorkloadsDashUrl,
                     "GRAFANA_NODEEXP_DASH_URL" : nodeExporterDashUrl,
                     "GRAFANA_NODES_DASH_URL" : nodesDashUrl,
-                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl,
-                    "GRAFANA_APISERVER_BASIC_DASH_URL": apiServerBasicDashUrl,
-                    "GRAFANA_APISERVER_ADVANCED_DASH_URL": apiServerAdvancedDashUrl,
-                    "GRAFANA_APISERVER_TROUBLESHOOTING_DASH_URL": apiServerTroubleshootingDashUrl
+                    "GRAFANA_WORKLOADS_DASH_URL" : workloadsDashUrl
                 },
             }),
             new GrafanaOperatorSecretAddon(),


### PR DESCRIPTION
Reverts aws-observability/cdk-aws-observability-accelerator#87

We will take time to add multiple kustomizations, as https://github.com/aws-observability/aws-observability-accelerator/pull/21
https://github.com/aws-observability/terraform-aws-observability-accelerator/pull/216 cancel the emergency