### PR TITLE
Update docs for Service accounts and Grafana v10

### DIFF
--- a/docs/patterns/existing-eks-observability-accelerators/existing-eks-adotmetrics-collection-observability.md
+++ b/docs/patterns/existing-eks-observability-accelerators/existing-eks-adotmetrics-collection-observability.md
@@ -54,17 +54,40 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
 Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 5. AWS SSM Parameter Store for GRAFANA API KEY: Update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 

--- a/docs/patterns/existing-eks-observability-accelerators/existing-eks-nginx-observability.md
+++ b/docs/patterns/existing-eks-observability-accelerators/existing-eks-nginx-observability.md
@@ -72,17 +72,40 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
 Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 5. AWS SSM Parameter Store for GRAFANA API KEY: Update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 

--- a/docs/patterns/existing-eks-observability-accelerators/existing-eks-opensource-observability.md
+++ b/docs/patterns/existing-eks-observability-accelerators/existing-eks-opensource-observability.md
@@ -80,17 +80,40 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
 Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 5. AWS SSM Parameter Store for GRAFANA API KEY: Update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-gpu-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-gpu-opensource-observability.md
@@ -64,17 +64,40 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
     Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 5. AWS SSM Parameter Store for GRAFANA API KEY: Update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-graviton-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-graviton-opensource-observability.md
@@ -67,17 +67,40 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
     Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 5. AWS Secrets Manager for GRAFANA API KEY: Update the Grafana API key secret in AWS Secrets using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 
@@ -375,15 +398,38 @@ If you observe, the the above `grafana-api-key error` in the logs, your grafana 
 
 - First, lets create a new Grafana API key.
 
-```bash
-export GO_AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key-new" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export GO_AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export GO_AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 - Finally, update the Grafana API key secret in AWS Secrets Manager using the above new Grafana API key:
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-inferentia-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-inferentia-opensource-observability.md
@@ -73,17 +73,40 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
     Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 5. AWS SSM Parameter Store for GRAFANA API KEY: Update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 

--- a/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-opensource-observability.md
+++ b/docs/patterns/single-new-eks-observability-accelerators/single-new-eks-opensource-observability.md
@@ -61,17 +61,41 @@ export COA_AMG_ENDPOINT_URL=https://g-xyz.grafana-workspace.us-east-1.amazonaws.
 !!! warning
     Setting up environment variables `COA_AMG_ENDPOINT_URL` and `AWS_REGION` is mandatory for successful execution of this pattern.
 
-4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys.
+4. GRAFANA API KEY: Amazon Managed Grafana provides a control plane API for generating Grafana API keys or Service Account Tokens.
 
-```bash
-export AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
+
 
 5. AWS SSM Parameter Store for GRAFANA API KEY: Update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key. This will be referenced by Grafana Operator deployment of our solution to access Amazon Managed Grafana from Amazon EKS Cluster
 
@@ -289,15 +313,38 @@ If you observe, the the above `grafana-api-key error` in the logs, your grafana 
 
 - First, lets create a new Grafana API key.
 
-```bash
-export GO_AMG_API_KEY=$(aws grafana create-workspace-api-key \
-  --key-name "grafana-operator-key-new" \
-  --key-role "ADMIN" \
-  --seconds-to-live 432000 \
-  --workspace-id $COA_AMG_WORKSPACE_ID \
-  --query key \
-  --output text)
-```
+=== "v10.4 & v9.4 workspaces"
+
+    ```bash
+    # IMPORTANT NOTE: skip this command if you already have a service token
+    GRAFANA_SA_ID=$(aws grafana create-workspace-service-account \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --grafana-role ADMIN \
+      --name cdk-accelerator-eks \
+      --query 'id' \
+      --output text)
+
+    # creates a new token
+    export GO_AMG_API_KEY=$(aws grafana create-workspace-service-account-token \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      -name "grafana-operator-key" \
+      --seconds-to-live 432000 \
+      --service-account-id $GRAFANA_SA_ID \
+      --query 'serviceAccountToken.key' \
+      --output text)
+    ```
+
+=== "v8.4 workspaces"
+
+    ```bash
+    export GO_AMG_API_KEY=$(aws grafana create-workspace-api-key \
+      --key-name "grafana-operator-key" \
+      --key-role "ADMIN" \
+      --seconds-to-live 432000 \
+      --workspace-id $COA_AMG_WORKSPACE_ID \
+      --query key \
+      --output text)
+    ```
 
 - Finally, update the Grafana API key secret in AWS SSM Parameter Store using the above new Grafana API key:
 


### PR DESCRIPTION
*Issue #, if available:*

Updated the docs to include MG v10. 

1/ I realized that there's a lot of duplication of commands. Maybe worth creating a single `pre-requisite` page with the same instructions centralized there? That could avoid update issues

2/ the `amg-preconfig.sh` uses `create-workspace-api-key` API, and maybe should evolve to use service accounts. This is fine for now, but could be an issue in future MG releases

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
