### PR TITLE
kubecost changes prevent otel collector to deploy

### DIFF
--- a/lib/single-new-eks-opensource-observability-pattern/index.ts
+++ b/lib/single-new-eks-opensource-observability-pattern/index.ts
@@ -92,7 +92,12 @@ export default class SingleNewEksOpenSourceobservabilityPattern {
             "{{ stop enableAdotContainerLogsExporter }}",
             jsonStringnew.context["adotcontainerlogs.pattern.enabled"]
         );
-        console.log(doc);
+        doc = utils.changeTextBetweenTokens(
+            doc,
+            "{{ start kubecostJob }}",
+            "{{ stop kubecostJob }}",
+            false
+        );
         fs.writeFileSync(__dirname + '/../common/resources/otel-collector-config-new.yml', doc);
 
         if (utils.valueFromContext(scope, "adotcollectormetrics.pattern.enabled", false)) {


### PR DESCRIPTION
kubecost uses another index file but uses the same otel-collector-config.yaml, so we need to remove "{{ start kubecostJob }}",
            "{{ stop kubecostJob }}",
for it to deploy successfully

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
