### PR TITLE
fix for: logs pipeline in OpenTelemetryCollector references undefined…

### DIFF
--- a/lib/common/resources/otel-collector-config.yml
+++ b/lib/common/resources/otel-collector-config.yml
@@ -1879,10 +1879,12 @@ spec:
         metrics:
           receivers: [prometheus]
           exporters: [logging, prometheusremotewrite]
+        {{ start enableAdotContainerLogsPipeline }}
         logs:
           receivers: [filelog]
           processors: [batch,k8sattributes]
           exporters: [awscloudwatchlogs]
+        {{ stop enableAdotContainerLogsPipeline }}
       {{ start enableAdotMetricsCollectionTelemetry }}
       telemetry:
         metrics:

--- a/lib/single-new-eks-opensource-observability-pattern/index.ts
+++ b/lib/single-new-eks-opensource-observability-pattern/index.ts
@@ -94,6 +94,12 @@ export default class SingleNewEksOpenSourceobservabilityPattern {
         );
         doc = utils.changeTextBetweenTokens(
             doc,
+            "{{ start enableAdotContainerLogsPipeline }}",
+            "{{ stop enableAdotContainerLogsPipeline }}",
+            jsonStringnew.context["adotcontainerlogs.pattern.enabled"]
+        );
+        doc = utils.changeTextBetweenTokens(
+            doc,
             "{{ start kubecostJob }}",
             "{{ stop kubecostJob }}",
             false


### PR DESCRIPTION
… receiver and exporter if adotcontainerlogs.pattern.enabled is not defined in cdk.json

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
