### PR TITLE
fix: Remove third-party check-user-permission action from e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,24 +3,15 @@ on:
   issue_comment:
     types: [created]
 jobs:
-  checkPermissions:
-    runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/do-e2e-test') # check the comment if it contains the keywords
-    steps:
-    - id: checkUserPermissions
-      uses: actions-cool/check-user-permission@main
-      with:    
-        require: 'admin'
-    outputs:
-      run_test: ${{ steps.checkUserPermissions.outputs.require-result }}
   e2ePipeline:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/do-e2e-test') && needs.checkPermissions.outputs.run_test == 'true'
-    needs:
-    - checkPermissions
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/do-e2e-test') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
     - name: Dump GitHub context
       env:
@@ -47,10 +38,6 @@ jobs:
       uses: aws-actions/aws-codebuild-run-build@v1
       with:
         project-name: cdk-pattern-test
-        # buildspec-override: path/to/buildspec.yaml or inline buildspec definition
-        # compute-type-override: compute-type
-        # environment-type-override: environment-type
-        # image-override: ecr-image-uri
         env-vars-for-codebuild: |
           PR_NUMBER,
           COMMIT_ID,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
